### PR TITLE
Possible fix

### DIFF
--- a/SampleLabel/AttributedText.swift
+++ b/SampleLabel/AttributedText.swift
@@ -16,6 +16,7 @@ struct AttributedText: UIViewRepresentable {
     let label = UILabel()
     label.numberOfLines = 0
     label.lineBreakMode = .byWordWrapping
+    label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     return label
   }
 


### PR DESCRIPTION
Set label's content compression resistance to `.defaultLow`, which will allow the label’s width to be squeezed by its parent. The other hugging/compression priorities seem to be okay by default.